### PR TITLE
Misc fixes: readme typo, %0 quoting, service stop/delete order

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ requirements :
 * `preset2_example.cmd` : интерактивный запуск стратегии-примера на базе winws2 (не является готовым лекарством)
 * `preset2_wireguard.cmd` : интерактивный запуск обхода блокировки wireguard протокола на любых портах
 * `service*.cmd` : установка и управление службой windows (режим неинтерактивного автозапуска). НЕ ЗАПУСКАТЬ БЕЗ РЕДАКТИРОВАНИЯ !
-* `enable_tcp_timestamps.cmd` : включить таймштампы tcp. по умолчанию отключены. требуются для ts fooling.
+* `enable_timestamps.cmd` : включить таймштампы tcp. по умолчанию отключены. требуются для ts fooling.
 * `windivert_delete.cmd` : остановить и удалить драйвер windivert
 * `killall.exe` : программа из cygwin для посылки unix сигналов winws
 * `elevator.exe` : запускает программы от имени администратора
@@ -70,7 +70,7 @@ This is not one-button solution to open sites. zapret understanding is required 
 * `preset2_example.cmd` : run interactively example strategy using winws2
 * `preset2_wireguard.cmd` : run interactively wireguard protocol bypass
 * `service*.cmd` : windows service setup and control (non-interactive autostart mode)
-* `enable_tcp_timestamps.cmd` : enable tcp timestamps. they are disabled by default and required for ts fooling.
+* `enable_timestamps.cmd` : enable tcp timestamps. they are disabled by default and required for ts fooling.
 * `windivert_delete.cmd` : stop and delete windivert driver
 * `killall.exe` : cygwin tool used in reload_lists.cmd. allows to send signals to winws.
 * `elevator.exe` : simple tool to run a program as admin

--- a/windivert-hide/monkey_delete.cmd
+++ b/windivert-hide/monkey_delete.cmd
@@ -2,8 +2,8 @@
 
 if "%1%" == "del" (
 	echo DELETE MONKEY DRIVER
-	sc delete monkey
 	sc stop monkey
+	sc delete monkey
 	goto :end
 )
 
@@ -14,7 +14,7 @@ echo.
 choice /C YN /M "Do you want to stop and delete monkey"
 if ERRORLEVEL 2 goto :eof
 
-"%~dp0..\tools\elevator" %0 del
+"%~dp0..\tools\elevator" "%~f0" del
 goto :eof
 
 :end

--- a/zapret-winws/enable_timestamps.cmd
+++ b/zapret-winws/enable_timestamps.cmd
@@ -6,7 +6,7 @@ if "%1%" == "doit" (
 	goto :end
 )
 
-"%~dp0elevator" %0 doit
+"%~dp0elevator" "%~f0" doit
 goto :eof
 
 :end

--- a/zapret-winws/windivert_delete.cmd
+++ b/zapret-winws/windivert_delete.cmd
@@ -2,8 +2,8 @@
 
 if "%1%" == "del" (
 	echo DELETE WINDIVERT DRIVER
-	sc delete windivert
 	sc stop windivert
+	sc delete windivert
 	goto :end
 )
 
@@ -14,7 +14,7 @@ echo.
 choice /C YN /M "Do you want to stop and delete windivert"
 if ERRORLEVEL 2 goto :eof
 
-"%~dp0elevator" %0 del
+"%~dp0elevator" "%~f0" del
 goto :eof
 
 :end


### PR DESCRIPTION
Small collection of fixes, split into two commits.

**1. Filename typo in readme**
`enable_tcp_timestamps.cmd` is referenced in both RU and EN sections,
but the actual file is `enable_timestamps.cmd`.

**2. Batch scripts: `%0` quoting + service order**
- Use `"%~f0"` instead of bare `%0` when re-invoking scripts via elevator,
  so paths with spaces work correctly.
  Affects: `enable_timestamps.cmd`, `windivert_delete.cmd`, `monkey_delete.cmd`
- Swap `sc delete` / `sc stop` order in `windivert_delete.cmd` and
  `monkey_delete.cmd` to match the convention used in `service_del.cmd`.